### PR TITLE
Running redis should be optional

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -144,7 +144,9 @@ PRIORITY_FEE_SCALER_10=0.1
 #     https://redis.io/docs/getting-started/
 # Under the hood, the relayer will cache JSON-rpc request data from requests
 # like `eth_getBlock` in the Redis DB.
-REDIS_URL="redis://127.0.0.1:6379"
+# Redis connection URL. Set to "" to disable Redis.
+# If you need Redis functionality, set to redis default "redis://127.0.0.1:6379"
+REDIS_URL=""
 
 # A namespace that will be used to prefix all keys in the Redis DB. This is
 # useful if multiple relayers are running on the same Redis instance. This

--- a/src/utils/RedisUtils.ts
+++ b/src/utils/RedisUtils.ts
@@ -72,7 +72,8 @@ export const REDIS_URL = process.env.REDIS_URL || REDIS_URL_DEFAULT;
 // Make the redis client for a particular url essentially a singleton.
 const redisClients: { [url: string]: RedisClient } = {};
 
-export async function getRedis(logger?: winston.Logger, url = REDIS_URL): Promise<RedisClient | undefined> {
+export async function getRedis(logger?: winston.Logger, url?: string): Promise<RedisClient | undefined> {
+  if (!url) return undefined;
   if (!redisClients[url]) {
     let redisClient: _RedisClient | undefined = undefined;
     const reconnectStrategy = (retries: number): number | Error => {


### PR DESCRIPTION
This allows running the relay without redis. Redis is only mentioned in advanced configurations and by default you should be able to set your REDIS_URL to ""